### PR TITLE
修复按量付费云盘询价报错

### DIFF
--- a/tencentcloud/cbs/v20170312/models.go
+++ b/tencentcloud/cbs/v20170312/models.go
@@ -1656,7 +1656,7 @@ type PrepayPrice struct {
 
 	// 后付费云盘原单价，单位：元。
 	// 注意：此字段可能返回 null，表示取不到有效值。
-	UnitPrice *string `json:"UnitPrice,omitempty" name:"UnitPrice"`
+	UnitPrice *float64 `json:"UnitPrice,omitempty" name:"UnitPrice"`
 
 	// 后付费云盘的计价单元，取值范围：<br><li>HOUR：表示后付费云盘的计价单元是按小时计算。
 	// 注意：此字段可能返回 null，表示取不到有效值。
@@ -1664,7 +1664,7 @@ type PrepayPrice struct {
 
 	// 后付费云盘折扣单价，单位：元。
 	// 注意：此字段可能返回 null，表示取不到有效值。
-	UnitPriceDiscount *string `json:"UnitPriceDiscount,omitempty" name:"UnitPriceDiscount"`
+	UnitPriceDiscount *float64 `json:"UnitPriceDiscount,omitempty" name:"UnitPriceDiscount"`
 
 	// 高精度后付费云盘原单价, 单位：元
 	// 注意：此字段可能返回 null，表示取不到有效值。


### PR DESCRIPTION
```
[TencentCloudSDKError] Code=ClientError.ParseJsonError, Message=Fail to parse json content: {"Response": {"RequestId": "47277e05-1a32-4cab-a31d-078c320ca7a3", "DiskPrice": {"DiscountPrice": null, "UnitPrice": 0.09, "UnitPriceHigh": "0.09", "OriginalPriceHigh": null, "OriginalPrice": null, "UnitPriceDiscount": 0.06, "UnitPriceDiscountHigh": "0.0612", "DiscountPriceHigh": null, "ChargeUnit": "HOUR"}}}, because: json: cannot unmarshal number into Go struct field PrepayPrice.Response.DiskPrice.UnitPriceDiscount of type string
```

UnitPrice 也有这个问题

