### PR TITLE
fix 添加cmq错误返回处理

### DIFF
--- a/tencentcloud/common/http/response.go
+++ b/tencentcloud/common/http/response.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"strconv"
+
 	//"log"
 	"net/http"
 
@@ -33,6 +35,12 @@ type DeprecatedAPIErrorResponse struct {
 	CodeDesc string `json:"codeDesc"`
 }
 
+type CMQAPIErrorResponse struct {
+	Code      int    `json:"code"`
+	Message   string `json:"message"`
+	RequestId string `json:"requestId"`
+}
+
 func (r *BaseResponse) ParseErrorFromHTTPResponse(body []byte) (err error) {
 	resp := &ErrorResponse{}
 	err = json.Unmarshal(body, resp)
@@ -42,6 +50,16 @@ func (r *BaseResponse) ParseErrorFromHTTPResponse(body []byte) (err error) {
 	}
 	if resp.Response.Error.Code != "" {
 		return errors.NewTencentCloudSDKError(resp.Response.Error.Code, resp.Response.Error.Message, resp.Response.RequestId)
+	}
+
+	cmqResp := &CMQAPIErrorResponse{}
+	err = json.Unmarshal(body, cmqResp)
+	if err != nil {
+		msg := fmt.Sprintf("Fail to parse json content: %s, because: %s", body, err)
+		return errors.NewTencentCloudSDKError("ClientError.ParseJsonError", msg, "")
+	}
+	if cmqResp.RequestId != "" {
+		return errors.NewTencentCloudSDKError(strconv.Itoa(cmqResp.Code), cmqResp.Message, cmqResp.RequestId)
 	}
 
 	deprecated := &DeprecatedAPIErrorResponse{}
@@ -65,6 +83,16 @@ func ParseErrorFromHTTPResponse(body []byte) (err error) {
 	}
 	if resp.Response.Error.Code != "" {
 		return errors.NewTencentCloudSDKError(resp.Response.Error.Code, resp.Response.Error.Message, resp.Response.RequestId)
+	}
+
+	cmqResp := &CMQAPIErrorResponse{}
+	err = json.Unmarshal(body, cmqResp)
+	if err != nil {
+		msg := fmt.Sprintf("Fail to parse json content: %s, because: %s", body, err)
+		return errors.NewTencentCloudSDKError("ClientError.ParseJsonError", msg, "")
+	}
+	if cmqResp.RequestId != "" {
+		return errors.NewTencentCloudSDKError(strconv.Itoa(cmqResp.Code), cmqResp.Message, cmqResp.RequestId)
 	}
 
 	deprecated := &DeprecatedAPIErrorResponse{}


### PR DESCRIPTION
CMQ返回的没有CodeDesc，我尝试过自己实现tchttp.Response接口传入，但是还有一个写死的ParseErrorFromHTTPResponse。我没有办法在CMQ出错的时候获取到Code。