### PR TITLE
fix: avoid overwriting user's log flag

### DIFF
--- a/tencentcloud/common/netretry.go
+++ b/tencentcloud/common/netretry.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"reflect"
@@ -33,7 +32,7 @@ func (c *Client) sendWithNetworkFailureRetry(req *http.Request, retryable bool) 
 			if err, ok := err.(net.Error); ok && (err.Timeout() || err.Temporary()) {
 				duration := durationFunc(idx)
 				if c.debug {
-					log.Printf(tplNetworkFailureRetry, idx, maxRetries, duration.Seconds(), err.Error())
+					c.logger.Printf(tplNetworkFailureRetry, idx, maxRetries, duration.Seconds(), err.Error())
 				}
 
 				time.Sleep(duration)

--- a/tencentcloud/common/ratelimitretry.go
+++ b/tencentcloud/common/ratelimitretry.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"time"
 
@@ -36,7 +35,7 @@ func (c *Client) sendWithRateLimitRetry(req *http.Request, retryable bool) (resp
 		if err, ok := err.(*errors.TencentCloudSDKError); ok && err.Code == codeLimitExceeded && idx < maxRetries {
 			duration := durationFunc(idx)
 			if c.debug {
-				log.Printf(tplRateLimitRetry, idx, maxRetries, duration.Seconds(), err.Error())
+				c.logger.Printf(tplRateLimitRetry, idx, maxRetries, duration.Seconds(), err.Error())
 			}
 
 			time.Sleep(duration)


### PR DESCRIPTION
Avoid setting flags on default logger, otherwise users using default logger might got affected.