### PR TITLE
fix: remove header warning for Content-Type

### DIFF
--- a/tencentcloud/common/client.go
+++ b/tencentcloud/common/client.go
@@ -300,7 +300,7 @@ func (c *Client) sendWithSignatureV3(request tchttp.Request, response tchttp.Res
 	for k, v := range request.GetHeader() {
 		switch k {
 		case "X-TC-Action", "X-TC-Version", "X-TC-Timestamp", "X-TC-RequestClient",
-			"X-TC-Language", "Content-Type", "X-TC-Region", "X-TC-Token":
+			"X-TC-Language", "X-TC-Region", "X-TC-Token":
 			c.logger.Printf("Skip header \"%s\": can not specify built-in header", k)
 		default:
 			headers[k] = v


### PR DESCRIPTION
删除针对 Content-Type 自定义 header 的warning, 因为内置方法 SetOctetStreamParameters 使用了该自定义 header