### PR TITLE
添加用于批量删除 GitHub 标签的 Go 脚本

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,65 @@
+# Go Script for Bulk GitHub Tag Deletion
+
+这是一个使用 Go 语言编写的命令行工具，用于高效地从 GitHub 仓库中批量删除标签。它特别适用于需要删除大量（例如，数千个甚至数十万个）标签的场景，因为传统的 GitHub API 逐个删除方法效率低下且容易触发速率限制。
+
+本工具利用 Git 协议的 `git push --delete` 命令来进行标签删除，这比通过 GitHub REST API 进行大量删除通常更高效。
+
+## 功能特性
+
+* 使用 `git ls-remote --tags` 高效获取所有远程标签列表，避免 REST API 的分页限制。
+* 支持通过正则表达式模式精确匹配要删除的标签。
+* 使用 `git push --delete` 命令通过 Git 协议进行删除。
+* 支持并发删除，提高处理速度。
+* 包含重要的用户确认步骤，防止误删。
+* 报告删除成功和失败的结果。
+
+## 先决条件
+
+在运行此脚本之前，你需要准备以下环境：
+
+1.  **Go 环境：** 需要安装 Go 语言环境（推荐最新版本）。
+2.  **Git：** 需要在你的系统上安装 Git。
+3.  **本地仓库克隆：** 你需要将目标 GitHub 仓库克隆到本地。**脚本必须在克隆的仓库目录下运行。**
+4.  **Git 推送权限：** 你的本地 Git 环境需要配置好推送到远程仓库的权限。这通常意味着：
+    * **使用 SSH Keys (推荐)：** 将你的 SSH 公钥添加到你的 GitHub 账号中，并确保本地 SSH Agent 正在运行。
+    * **使用 HTTPS 和 Personal Access Token (PAT)：** 配置 Git Credential Helper 来缓存一个具有足够权限（至少 `repo` 或 `write:packages` 范围）的 GitHub PAT。**脚本本身不直接使用 PAT，它依赖你的 Git 配置来处理认证。**
+
+## 构建脚本
+
+1.  将脚本代码保存到你的本地仓库目录下，例如命名为 `delete_large_tags.go`。
+2.  在终端中进入到你的本地仓库目录。
+3.  运行 Go 构建命令：
+    ```bash
+    go build delete_large_tags.go
+    ```
+    这会在当前目录下生成一个名为 `delete_large_tags` (或者在 Windows 上是 `delete_large_tags.exe`) 的可执行文件。
+
+## 使用方法
+
+在终端中，**切换到你的本地仓库目录**，然后运行生成的可执行文件，并提供一个正则表达式作为参数来指定要删除哪些标签。
+
+```bash
+./delete_large_tags <tag_pattern>
+```
+
+- `tag_pattern`：一个必需参数，表示用于匹配要删除标签名称的正则表达式。
+
+**重要提示：** 在开始删除之前，脚本会列出匹配到的标签数量（以及部分名称），并要求你输入 yes 来确认删除。请务必仔细检查！
+
+## 示例
+
+1. 删除所有以 old- 开头的标签：
+```bash
+./delete_large_tags '^old-.*'
+```
+2. 删除所有版本号小于 2.0 的标签 (需要更复杂的模式或二次过滤)：
+（例如，删除 v1.0, v1.1, v1.9 但保留 v2.0, v2.1 等）
+```bash
+./delete_large_tags '^v1\.\d+$'
+# 或者删除所有以 v1. 开头的标签
+# ./delete_large_tags '^v1\.'
+```
+3. 删除所有标签（极度危险！请务必确认！）：
+```bash
+./delete_large_tags '.*'
+```

--- a/scripts/delete_large_tags.go
+++ b/scripts/delete_large_tags.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// 用于传递删除结果的结构体
+type deleteResult struct {
+	TagName string
+	Err     error
+	Output  string // 记录执行 git push 的输出，方便调试
+}
+
+func main() {
+	// 检查参数
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <tag_pattern>\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Example: %s '^old-.*'\n", os.Args[0]) // 删除所有以 'old-' 开头的标签
+		os.Exit(1)
+	}
+
+	tagPattern := os.Args[1]
+	remoteName := "origin" // 默认远程名称，如果你的远程不是 origin，请修改
+
+	// 检查是否在 Git 仓库目录下
+	if _, err := os.Stat(".git"); os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "Error: Must be run inside a Git repository clone.\n")
+		os.Exit(1)
+	}
+
+	// 编译正则表达式
+	regex, err := regexp.Compile(tagPattern)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error compiling regex pattern '%s': %v\n", tagPattern, err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Fetching tags from remote '%s'...\n", remoteName)
+
+	// 1. 获取远程仓库所有标签列表
+	// git ls-remote --tags origin
+	cmdLsRemote := exec.CommandContext(context.Background(), "git", "ls-remote", "--tags", remoteName)
+	stdout, err := cmdLsRemote.StdoutPipe()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating stdout pipe for git ls-remote: %v\n", err)
+		os.Exit(1)
+	}
+	if err := cmdLsRemote.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error starting git ls-remote: %v\n", err)
+		os.Exit(1)
+	}
+
+	var allRemoteTags []string
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.Fields(line)
+		if len(parts) == 2 {
+			ref := parts[1]
+			// 提取标签名称，确保是 refs/tags/ 开头
+			if strings.HasPrefix(ref, "refs/tags/") {
+				tagName := strings.TrimPrefix(ref, "refs/tags/")
+				allRemoteTags = append(allRemoteTags, tagName)
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading git ls-remote output: %v\n", err)
+		// 尝试等待命令结束，获取可能的错误信息
+		cmdLsRemote.Wait()
+		os.Exit(1)
+	}
+
+	// 等待 git ls-remote 命令完成
+	if err := cmdLsRemote.Wait(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error executing git ls-remote: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Found %d remote tags.\n", len(allRemoteTags))
+	fmt.Printf("Filtering tags matching pattern: '%s'\n", tagPattern)
+
+	// 2. 筛选要删除的标签
+	var tagsToDelete []string
+	for _, tagName := range allRemoteTags {
+		if regex.MatchString(tagName) {
+			tagsToDelete = append(tagsToDelete, tagName)
+		}
+	}
+
+	if len(tagsToDelete) == 0 {
+		fmt.Println("No tags found matching the pattern. Nothing to delete.")
+		os.Exit(0)
+	}
+
+	fmt.Printf("Found %d tags to delete:\n", len(tagsToDelete))
+	// 为了避免打印 200k 个标签，只打印前 100 个或一部分
+	displayLimit := 100
+	if len(tagsToDelete) > displayLimit {
+		for i := 0; i < displayLimit; i++ {
+			fmt.Println(tagsToDelete[i])
+		}
+		fmt.Printf("... and %d more.\n", len(tagsToDelete)-displayLimit)
+	} else {
+		for _, tag := range tagsToDelete {
+			fmt.Println(tag)
+		}
+	}
+
+	// 3. 确认删除
+	fmt.Print("\nAre you sure you want to delete the listed tags? (yes/no): ")
+	reader := bufio.NewReader(os.Stdin)
+	confirmation, _ := reader.ReadString('\n')
+	confirmation = strings.ToLower(strings.TrimSpace(confirmation))
+
+	if confirmation != "yes" {
+		fmt.Println("Deletion cancelled.")
+		os.Exit(0)
+	}
+
+	fmt.Println("Starting deletion process...")
+
+	// 4. 并发删除标签
+	// 使用 Goroutines 池来并发执行 git push --delete
+	const numWorkers = 20 // 可以根据你的网络和机器性能调整并发数
+	tagsChan := make(chan string, len(tagsToDelete))
+	resultsChan := make(chan deleteResult, len(tagsToDelete)) // Buffered channel for results
+
+	var wg sync.WaitGroup
+
+	// 启动 worker Goroutines
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go deleteWorker(tagsChan, resultsChan, &wg, remoteName)
+	}
+
+	// 将要删除的标签发送到 channel
+	for _, tag := range tagsToDelete {
+		tagsChan <- tag
+	}
+	close(tagsChan) // 关闭 channel，信号 worker 没有更多任务了
+
+	// 等待所有 worker 完成
+	wg.Wait()
+	close(resultsChan) // 关闭结果 channel
+
+	// 5. 收集和报告结果
+	deletedCount := 0
+	var failedTags []deleteResult
+	for res := range resultsChan {
+		if res.Err == nil {
+			deletedCount++
+			// 可以选择在这里打印成功的标签，但对于大量标签可能刷屏
+			// fmt.Printf("Successfully deleted %s\n", res.TagName)
+		} else {
+			failedTags = append(failedTags, res)
+			fmt.Fprintf(os.Stderr, "Error deleting %s: %v\nOutput: %s\n", res.TagName, res.Err, res.Output)
+		}
+	}
+
+	fmt.Println("\nDeletion process finished.")
+	fmt.Printf("Deleted %d tags.\n", deletedCount)
+
+	if len(failedTags) > 0 {
+		fmt.Fprintf(os.Stderr, "Failed to delete %d tags.\n", len(failedTags))
+		fmt.Fprintf(os.Stderr, "Failed tags:\n")
+		// 只打印一部分失败的标签，避免输出过多
+		displayLimit = 100
+		for i, res := range failedTags {
+			if i >= displayLimit {
+				fmt.Fprintf(os.Stderr, "... and %d more.\n", len(failedTags)-displayLimit)
+				break
+			}
+			fmt.Fprintf(os.Stderr, "- %s\n", res.TagName)
+		}
+	}
+}
+
+// deleteWorker 是一个 Goroutine，从 tagsChan 读取标签并执行删除命令
+func deleteWorker(tagsChan <-chan string, resultsChan chan<- deleteResult, wg *sync.WaitGroup, remoteName string) {
+	defer wg.Done()
+
+	for tagName := range tagsChan {
+		// git push origin --delete <tag_name>
+		cmdDelete := exec.CommandContext(context.Background(), "git", "push", remoteName, "--delete", tagName)
+		output, err := cmdDelete.CombinedOutput() // 捕获 stdout 和 stderr
+
+		// 将结果发送回主 Goroutine
+		resultsChan <- deleteResult{
+			TagName: tagName,
+			Err:     err,
+			Output:  string(output),
+		}
+
+		// 可选：在 worker 之间添加短暂的延迟
+		// time.Sleep(50 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
此 PR 引入了一个 Go 语言脚本，旨在高效地批量删除 GitHub 仓库中的标签。

**动机：**

当仓库中存在大量（数千甚至数十万）标签时，通过 GitHub REST API 逐个删除效率低下且容易触发速率限制。此脚本提供了一个更健壮、性能更好的解决方案来应对这种情况。

**主要变更：**

* 添加了一个 Go 命令行工具 (`delete_large_tags.go`)。
* 脚本使用 `git ls-remote --tags` 获取所有远程标签。
* 根据用户提供的正则表达式模式筛选标签。
* 利用 Go 的并发特性，通过 `os/exec` 并发执行 `git push --delete` 命令来删除匹配的标签。
* 包含一个重要的删除前确认步骤。

**使用说明：**

脚本需要在目标仓库的本地克隆目录下运行。它依赖于本地 Git 环境的安装和推送权限配置（例如，通过 SSH 或配置了 PAT 的凭据管理器）。

示例用法：`./delete_large_tags '^old-.*'`

这个脚本为仓库维护者提供了一个实用工具，可以高效地清理大量过时或不需要的标签。