### PR TITLE
fix(sse): raise scanner buffer cap to 128MB

### DIFF
--- a/tencentcloud/common/http/response.go
+++ b/tencentcloud/common/http/response.go
@@ -4,10 +4,11 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/json"
 	"io/ioutil"
 	"log"
 	"strconv"
+
+	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/json"
 
 	//"log"
 	"net/http"
@@ -191,6 +192,8 @@ func parseFromSSE(hr *http.Response, resp Response) error {
 		defer close(ch)
 
 		scanner := bufio.NewScanner(hr.Body)
+		const MB = 1024 * 1024
+		scanner.Buffer(nil, MB*32)
 		scanner.Split(bufio.ScanLines)
 
 		event := SSEvent{}


### PR DESCRIPTION
Default bufio.Scanner max token size is 64KB; long SSE lines (e.g. Hunyuan streaming JSON payloads) exceed this and cause Scan to stop silently with bufio.ErrTooLong. Bump max to 128MB. Buffer grows lazily, so idle streams pay no extra memory.