### PR TITLE
fix(common): circuit breaker + error wrapping

### DIFF
--- a/tencentcloud/common/circuit_breaker.go
+++ b/tencentcloud/common/circuit_breaker.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	tcerr "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
 )
 
 const (
@@ -15,6 +17,10 @@ const (
 	defaultMaxFailPercentage = 75
 	defaultWindowLength      = 1 * 60 * time.Second
 	defaultTimeout           = 60 * time.Second
+	// defaultMaxRequests is the number of consecutive successful probe
+	// requests required in StateHalfOpen before the breaker transitions
+	// back to StateClosed.
+	defaultMaxRequests = 5
 )
 
 var (
@@ -22,8 +28,8 @@ var (
 	errOpenState = errors.New("circuit breaker is open")
 )
 
-// counter use atomic operations to ensure consistency
-// Atomic operations perform better than mutex
+// counter is not safe for concurrent use on its own; callers must
+// synchronize access via the enclosing circuitBreaker's mutex.
 type counter struct {
 	failures             int
 	all                  int
@@ -50,13 +56,14 @@ func (c *counter) onFailure() {
 	c.all++
 	c.failures++
 	c.consecutiveSuccesses = 0
-	c.consecutiveSuccesses = 0
+	c.consecutiveFailures++
 }
 
 func (c *counter) clear() {
 	c.all = 0
 	c.failures = 0
 	c.consecutiveSuccesses = 0
+	c.consecutiveFailures = 0
 }
 
 // State is a type that represents a state of CircuitBreaker.
@@ -80,7 +87,7 @@ type breakerSetting struct {
 	// the default is 75/100
 	maxFailPercentage int
 	// windowInterval decides when to reset counter if the state is StateClosed
-	// the default is 5minutes
+	// the default is 1 minute
 	windowInterval time.Duration
 	// timeout decides when to turn StateOpen to StateHalfOpen
 	// the default is 60s
@@ -120,6 +127,7 @@ func defaultRegionBreaker() *circuitBreaker {
 		maxFailPercentage: defaultMaxFailPercentage,
 		windowInterval:    defaultWindowLength,
 		timeout:           defaultTimeout,
+		maxRequests:       defaultMaxRequests,
 	}
 	return newRegionBreaker(defaultSet)
 }
@@ -214,7 +222,7 @@ func (s *circuitBreaker) onSuccess(state state, now time.Time) {
 func (s *circuitBreaker) readyToOpen(c counter) bool {
 	failPre := float64(c.failures) / float64(c.all)
 	return (c.failures >= s.maxFailNum && failPre >= float64(s.maxFailPercentage)/100.0) ||
-		c.consecutiveFailures > 5
+		c.consecutiveFailures >= s.maxFailNum
 }
 
 func (s *circuitBreaker) onFailure(state state, now time.Time) {
@@ -256,4 +264,38 @@ func renewUrl(oldDomain, region string) string {
 	}
 	newDomain := strings.Join(ss, ".")
 	return newDomain
+}
+
+// isBreakerSuccess decides whether a sendWithSignature result counts as a
+// success for the regional circuit breaker.
+//
+// The breaker tracks region health, not per-call business outcome. So:
+//   - nil err: the request round-tripped and parsed cleanly → region healthy.
+//   - *TencentCloudSDKError with a RequestId: the region answered with a
+//     structured error (e.g. AuthFailure). The user's call failed but the
+//     region is up → success for breaker accounting. The single exception is
+//     "InternalError", which the API uses to signal a region-side fault.
+//   - Anything else (transport errors, locally-fabricated errors with no
+//     RequestId): the region did not answer → failure.
+//
+// This helper exists because the previous inline logic in sendWithRegionBreaker
+// only set isSuccess=true inside the `err.(*TencentCloudSDKError)` branch,
+// silently classifying every nil-error (i.e. genuinely successful) call as a
+// failure. After 5 successes the breaker would open and route traffic to the
+// backup endpoint.
+func isBreakerSuccess(err error) bool {
+	if err == nil {
+		return true
+	}
+	e, ok := err.(*tcerr.TencentCloudSDKError)
+	if !ok {
+		return false
+	}
+	if e.GetRequestId() == "" {
+		return false
+	}
+	if e.GetCode() == "InternalError" {
+		return false
+	}
+	return true
 }

--- a/tencentcloud/common/circuit_breaker_test.go
+++ b/tencentcloud/common/circuit_breaker_test.go
@@ -1,6 +1,12 @@
 package common
 
-import "testing"
+import (
+	"errors"
+	"testing"
+	"time"
+
+	tcerr "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/errors"
+)
 
 func Test_checkDomain(t *testing.T) {
 	type args struct {
@@ -51,5 +57,228 @@ func Test_renewUrl(t *testing.T) {
 				t.Errorf("renewUrl() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// Test_counter_onFailure_incrementsConsecutiveFailures guards against the typo in
+// counter.onFailure where consecutiveSuccesses was being zeroed twice instead of
+// incrementing consecutiveFailures. Symptom: the "consecutive failures" trip
+// branch in readyToOpen was unreachable dead code.
+func Test_counter_onFailure_incrementsConsecutiveFailures(t *testing.T) {
+	c := newRegionCounter()
+	for i := 0; i < 6; i++ {
+		c.onFailure()
+	}
+	if c.consecutiveFailures != 6 {
+		t.Fatalf("after 6 onFailure calls, consecutiveFailures = %d, want 6", c.consecutiveFailures)
+	}
+	if c.failures != 6 || c.all != 6 {
+		t.Fatalf("after 6 onFailure calls, failures=%d all=%d, want 6/6", c.failures, c.all)
+	}
+}
+
+// Test_counter_onSuccess_resetsConsecutiveFailures verifies that a single success
+// resets consecutiveFailures back to zero (the well-known burst recovery contract).
+func Test_counter_onSuccess_resetsConsecutiveFailures(t *testing.T) {
+	c := newRegionCounter()
+	c.onFailure()
+	c.onFailure()
+	c.onSuccess()
+	if c.consecutiveFailures != 0 {
+		t.Fatalf("after onSuccess, consecutiveFailures = %d, want 0", c.consecutiveFailures)
+	}
+}
+
+// Test_counter_clear_resetsConsecutiveFailures guards against counter.clear() forgetting
+// to reset consecutiveFailures. Without this, generation rollovers carry over a stale
+// failure count.
+func Test_counter_clear_resetsConsecutiveFailures(t *testing.T) {
+	c := newRegionCounter()
+	c.onFailure()
+	c.onFailure()
+	c.clear()
+	if c.consecutiveFailures != 0 {
+		t.Fatalf("after clear, consecutiveFailures = %d, want 0", c.consecutiveFailures)
+	}
+	if c.failures != 0 || c.all != 0 || c.consecutiveSuccesses != 0 {
+		t.Fatalf("after clear, failures=%d all=%d consecutiveSuccesses=%d, want all 0",
+			c.failures, c.all, c.consecutiveSuccesses)
+	}
+}
+
+// Test_circuitBreaker_tripsOnConsecutiveFailures verifies the consecutive-failures
+// trip branch fires once consecutiveFailures reaches maxFailNum.
+func Test_circuitBreaker_tripsOnConsecutiveFailures(t *testing.T) {
+	cb := newRegionBreaker(breakerSetting{
+		backupEndpoint:    defaultBackupEndpoint,
+		maxFailNum:        5,
+		maxFailPercentage: 75,
+		windowInterval:    1 * time.Hour,
+		timeout:           60 * time.Second,
+		maxRequests:       defaultMaxRequests,
+	})
+	for i := 0; i < 5; i++ {
+		gen, err := cb.beforeRequest()
+		if err != nil {
+			t.Fatalf("iteration %d: beforeRequest returned err=%v before breaker should open", i, err)
+		}
+		cb.afterRequest(gen, false)
+	}
+	// After 5 consecutive failures the breaker must be open.
+	_, err := cb.beforeRequest()
+	if err != errOpenState {
+		t.Fatalf("after 5 consecutive failures, breaker should be open, got err=%v", err)
+	}
+}
+
+// Test_isBreakerSuccess_nilErrIsSuccess is the regression test for the bug where
+// sendWithRegionBreaker treated nil err as failure. nil err must be classified as
+// success, otherwise every successful API call counts as a failure to the breaker.
+func Test_isBreakerSuccess_nilErrIsSuccess(t *testing.T) {
+	if !isBreakerSuccess(nil) {
+		t.Fatal("isBreakerSuccess(nil) = false, want true (nil error is a successful call)")
+	}
+}
+
+// Test_isBreakerSuccess_sdkErrorWithRequestIdIsSuccess: a structured server error
+// with a RequestId still indicates the region answered, so the breaker should treat it
+// as success unless it is an InternalError.
+func Test_isBreakerSuccess_sdkErrorWithRequestIdIsSuccess(t *testing.T) {
+	e := tcerr.NewTencentCloudSDKError("AuthFailure.SignatureExpire", "expired", "req-123")
+	if !isBreakerSuccess(e) {
+		t.Fatal("isBreakerSuccess(AuthFailure with RequestId) = false, want true")
+	}
+}
+
+// Test_isBreakerSuccess_internalErrorIsFailure: InternalError indicates region-side
+// fault; treat as a failure for breaker accounting.
+func Test_isBreakerSuccess_internalErrorIsFailure(t *testing.T) {
+	e := tcerr.NewTencentCloudSDKError("InternalError", "boom", "req-123")
+	if isBreakerSuccess(e) {
+		t.Fatal("isBreakerSuccess(InternalError) = true, want false")
+	}
+}
+
+// Test_isBreakerSuccess_sdkErrorWithoutRequestIdIsFailure: missing RequestId means
+// the response never reached the user from the region (locally-fabricated error,
+// network failure mid-flight, etc.), so the breaker should consider it a failure.
+func Test_isBreakerSuccess_sdkErrorWithoutRequestIdIsFailure(t *testing.T) {
+	e := tcerr.NewTencentCloudSDKError("ClientError.NetworkError", "boom", "")
+	if isBreakerSuccess(e) {
+		t.Fatal("isBreakerSuccess(SDKError without RequestId) = true, want false")
+	}
+}
+
+// Test_isBreakerSuccess_nonSDKErrorIsFailure: arbitrary network/transport error must
+// be a failure.
+func Test_isBreakerSuccess_nonSDKErrorIsFailure(t *testing.T) {
+	if isBreakerSuccess(errors.New("connection refused")) {
+		t.Fatal("isBreakerSuccess(non-SDK error) = true, want false")
+	}
+}
+
+// Test_circuitBreaker_doesNotOpenOnSuccesses is the integration-level regression test:
+// 5 successful calls in a row must NOT open the breaker, otherwise users get silent
+// wrong-region routing.
+func Test_circuitBreaker_doesNotOpenOnSuccesses(t *testing.T) {
+	cb := defaultRegionBreaker()
+	for i := 0; i < 10; i++ {
+		gen, err := cb.beforeRequest()
+		if err != nil {
+			t.Fatalf("iteration %d: breaker opened spuriously, err=%v", i, err)
+		}
+		// Simulate a successful call: nil error -> isBreakerSuccess returns true.
+		cb.afterRequest(gen, isBreakerSuccess(nil))
+	}
+	// Confirm state is still closed.
+	cb.mu.Lock()
+	st := cb.state
+	cb.mu.Unlock()
+	if st != StateClosed {
+		t.Fatalf("after 10 successes, breaker state = %v, want StateClosed", st)
+	}
+}
+
+// Test_circuitBreaker_generationRollover_clearsConsecutiveFailures guards against
+// consecutiveFailures surviving a generation rollover.
+func Test_circuitBreaker_generationRollover_clearsConsecutiveFailures(t *testing.T) {
+	cb := newRegionBreaker(breakerSetting{
+		backupEndpoint:    defaultBackupEndpoint,
+		maxFailNum:        5,
+		maxFailPercentage: 75,
+		windowInterval:    1 * time.Millisecond,
+		timeout:           60 * time.Second,
+		maxRequests:       defaultMaxRequests,
+	})
+	// Record a few failures (not enough to trip).
+	for i := 0; i < 3; i++ {
+		gen, err := cb.beforeRequest()
+		if err != nil {
+			t.Fatalf("iteration %d: unexpected err=%v", i, err)
+		}
+		cb.afterRequest(gen, false)
+	}
+	// Wait past windowInterval so the next beforeRequest rolls a new generation.
+	time.Sleep(5 * time.Millisecond)
+	_, err := cb.beforeRequest()
+	if err != nil {
+		t.Fatalf("after rollover, unexpected err=%v", err)
+	}
+	cb.mu.Lock()
+	cf := cb.counter.consecutiveFailures
+	all := cb.counter.all
+	failures := cb.counter.failures
+	cb.mu.Unlock()
+	if cf != 0 || all != 0 || failures != 0 {
+		t.Fatalf("after generation rollover counter not cleared: consecutiveFailures=%d failures=%d all=%d",
+			cf, failures, all)
+	}
+}
+
+// Test_circuitBreaker_halfOpenRequiresMaxRequests verifies that the half-open ->
+// closed transition waits for maxRequests consecutive successes, rather than
+// closing on the first success. Regression test for the missing maxRequests
+// default in defaultRegionBreaker.
+func Test_circuitBreaker_halfOpenRequiresMaxRequests(t *testing.T) {
+	cb := newRegionBreaker(breakerSetting{
+		backupEndpoint:    defaultBackupEndpoint,
+		maxFailNum:        5,
+		maxFailPercentage: 75,
+		windowInterval:    1 * time.Hour,
+		timeout:           1 * time.Millisecond, // trip fast for the test
+		maxRequests:       3,
+	})
+	// Trip the breaker with 5 consecutive failures.
+	for i := 0; i < 5; i++ {
+		gen, _ := cb.beforeRequest()
+		cb.afterRequest(gen, false)
+	}
+	if _, err := cb.beforeRequest(); err != errOpenState {
+		t.Fatalf("expected breaker open after 5 failures, got %v", err)
+	}
+	// Wait past timeout so next beforeRequest moves to half-open.
+	time.Sleep(5 * time.Millisecond)
+	// Send 2 successes: not enough, breaker should still be half-open.
+	for i := 0; i < 2; i++ {
+		gen, err := cb.beforeRequest()
+		if err != nil {
+			t.Fatalf("half-open iteration %d: unexpected err=%v", i, err)
+		}
+		cb.afterRequest(gen, true)
+	}
+	cb.mu.Lock()
+	st := cb.state
+	cb.mu.Unlock()
+	if st != StateHalfOpen {
+		t.Fatalf("after 2 successes in half-open, state = %v, want StateHalfOpen", st)
+	}
+	// Third success should close.
+	gen, _ := cb.beforeRequest()
+	cb.afterRequest(gen, true)
+	cb.mu.Lock()
+	st = cb.state
+	cb.mu.Unlock()
+	if st != StateClosed {
+		t.Fatalf("after 3 successes in half-open, state = %v, want StateClosed", st)
 	}
 }

--- a/tencentcloud/common/client.go
+++ b/tencentcloud/common/client.go
@@ -145,14 +145,7 @@ func (c *Client) sendWithRegionBreaker(request tchttp.Request, response tchttp.R
 		request.SetDomain(newEndpoint)
 	}
 	err = c.sendWithSignature(request, response)
-	isSuccess := false
-	// Success is considered only when the server returns an effective response (have requestId and the code is not InternalError )
-	if e, ok := err.(*tcerr.TencentCloudSDKError); ok {
-		if e.GetRequestId() != "" && e.GetCode() != "InternalError" {
-			isSuccess = true
-		}
-	}
-	c.rb.afterRequest(ge, isSuccess)
+	c.rb.afterRequest(ge, isBreakerSuccess(err))
 	return err
 }
 

--- a/tencentcloud/common/errors/errors.go
+++ b/tencentcloud/common/errors/errors.go
@@ -8,13 +8,22 @@ type TencentCloudSDKError struct {
 	Code      string
 	Message   string
 	RequestId string
+	cause     error
 }
 
 func (e *TencentCloudSDKError) Error() string {
-	if e.RequestId == "" {
-		return fmt.Sprintf("[TencentCloudSDKError] Code=%s, Message=%s", e.Code, e.Message)
+	var cause string
+	if e.cause != nil {
+		cause = ": " + e.cause.Error()
 	}
-	return fmt.Sprintf("[TencentCloudSDKError] Code=%s, Message=%s, RequestId=%s", e.Code, e.Message, e.RequestId)
+	if e.RequestId == "" {
+		return fmt.Sprintf("[TencentCloudSDKError] Code=%s, Message=%s%s", e.Code, e.Message, cause)
+	}
+	return fmt.Sprintf("[TencentCloudSDKError] Code=%s, Message=%s, RequestId=%s%s", e.Code, e.Message, e.RequestId, cause)
+}
+
+func (e *TencentCloudSDKError) Unwrap() error {
+	return e.cause
 }
 
 func NewTencentCloudSDKError(code, message, requestId string) error {
@@ -22,6 +31,20 @@ func NewTencentCloudSDKError(code, message, requestId string) error {
 		Code:      code,
 		Message:   message,
 		RequestId: requestId,
+	}
+}
+
+// NewTencentCloudSDKErrorWithCause wraps cause as a TencentCloudSDKError so
+// callers get a typed SDK error while the original error remains reachable
+// via errors.Is / errors.As / Unwrap. Use this instead of NewTencentCloudSDKError
+// whenever you are converting an existing Go error (network error, json parse
+// error, etc.) — otherwise the original error type is lost.
+func NewTencentCloudSDKErrorWithCause(code, message, requestId string, cause error) error {
+	return &TencentCloudSDKError{
+		Code:      code,
+		Message:   message,
+		RequestId: requestId,
+		cause:     cause,
 	}
 }
 

--- a/tencentcloud/common/errors/errors_test.go
+++ b/tencentcloud/common/errors/errors_test.go
@@ -1,0 +1,116 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestTencentCloudSDKError_Error(t *testing.T) {
+	cases := []struct {
+		name string
+		err  *TencentCloudSDKError
+		want string
+	}{
+		{
+			name: "no request id, no cause",
+			err:  &TencentCloudSDKError{Code: "ClientError.NetworkError", Message: "Fail to get response"},
+			want: "[TencentCloudSDKError] Code=ClientError.NetworkError, Message=Fail to get response",
+		},
+		{
+			name: "with request id, no cause",
+			err:  &TencentCloudSDKError{Code: "RequestLimitExceeded", Message: "rate limited", RequestId: "req-1"},
+			want: "[TencentCloudSDKError] Code=RequestLimitExceeded, Message=rate limited, RequestId=req-1",
+		},
+		{
+			name: "no request id, with cause",
+			err:  &TencentCloudSDKError{Code: "ClientError.NetworkError", Message: "Fail to get response", cause: fmt.Errorf("dial tcp: connection refused")},
+			want: "[TencentCloudSDKError] Code=ClientError.NetworkError, Message=Fail to get response: dial tcp: connection refused",
+		},
+		{
+			name: "with request id, with cause",
+			err:  &TencentCloudSDKError{Code: "ClientError.ParseJsonError", Message: "bad json", RequestId: "req-2", cause: fmt.Errorf("unexpected end of JSON input")},
+			want: "[TencentCloudSDKError] Code=ClientError.ParseJsonError, Message=bad json, RequestId=req-2: unexpected end of JSON input",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Error(); got != tc.want {
+				t.Fatalf("Error() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTencentCloudSDKError_Unwrap(t *testing.T) {
+	t.Run("nil cause returns nil", func(t *testing.T) {
+		e := &TencentCloudSDKError{Code: "c", Message: "m"}
+		if got := e.Unwrap(); got != nil {
+			t.Fatalf("Unwrap() = %v, want nil", got)
+		}
+	})
+
+	t.Run("cause is returned", func(t *testing.T) {
+		cause := fmt.Errorf("underlying")
+		e := &TencentCloudSDKError{Code: "c", Message: "m", cause: cause}
+		if got := e.Unwrap(); got != cause {
+			t.Fatalf("Unwrap() = %v, want %v", got, cause)
+		}
+	})
+
+	t.Run("errors.Is traverses chain", func(t *testing.T) {
+		sentinel := fmt.Errorf("sentinel")
+		e := NewTencentCloudSDKErrorWithCause("c", "m", "", sentinel)
+		if !errors.Is(e, sentinel) {
+			t.Fatalf("errors.Is(e, sentinel) = false, want true")
+		}
+	})
+
+	t.Run("errors.As traverses chain", func(t *testing.T) {
+		cause := &timeoutErrImpl{msg: "boom"}
+		e := NewTencentCloudSDKErrorWithCause("c", "m", "", cause)
+		var got *timeoutErrImpl
+		if !errors.As(e, &got) {
+			t.Fatalf("errors.As(e, &timeoutErrImpl) = false, want true")
+		}
+		if got.msg != "boom" {
+			t.Fatalf("got.msg = %q, want %q", got.msg, "boom")
+		}
+	})
+}
+
+func TestNewTencentCloudSDKError_NoCause(t *testing.T) {
+	e := NewTencentCloudSDKError("c", "m", "r")
+	sdk, ok := e.(*TencentCloudSDKError)
+	if !ok {
+		t.Fatalf("expected *TencentCloudSDKError, got %T", e)
+	}
+	if sdk.Unwrap() != nil {
+		t.Fatalf("Unwrap() = %v, want nil for error created without cause", sdk.Unwrap())
+	}
+	if got := e.Error(); got != "[TencentCloudSDKError] Code=c, Message=m, RequestId=r" {
+		t.Fatalf("Error() = %q, want no cause suffix", got)
+	}
+}
+
+func TestNewTencentCloudSDKErrorWithCause(t *testing.T) {
+	cause := fmt.Errorf("root")
+	e := NewTencentCloudSDKErrorWithCause("c", "m", "r", cause)
+	sdk, ok := e.(*TencentCloudSDKError)
+	if !ok {
+		t.Fatalf("expected *TencentCloudSDKError, got %T", e)
+	}
+	if sdk.Unwrap() != cause {
+		t.Fatalf("Unwrap() = %v, want %v", sdk.Unwrap(), cause)
+	}
+	// Error() must include cause text.
+	if got := e.Error(); got != "[TencentCloudSDKError] Code=c, Message=m, RequestId=r: root" {
+		t.Fatalf("Error() = %q, want cause suffix", got)
+	}
+}
+
+// timeoutErrImpl is a plain error type used to verify errors.As reaches
+// through TencentCloudSDKError's Unwrap chain.
+type timeoutErrImpl struct{ msg string }
+
+func (e *timeoutErrImpl) Error() string { return e.msg }

--- a/tencentcloud/common/netretry.go
+++ b/tencentcloud/common/netretry.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"fmt"
 	"net"
 	"net/http"
 	"reflect"
@@ -50,8 +49,7 @@ func (c *Client) sendWithNetworkFailureRetry(req *http.Request, retryable bool) 
 		}
 
 		if err != nil {
-			msg := fmt.Sprintf("Fail to get response because %s", err)
-			err = errors.NewTencentCloudSDKError("ClientError.NetworkError", msg, "")
+			err = errors.NewTencentCloudSDKErrorWithCause("ClientError.NetworkError", "Fail to get response", "", err)
 		}
 
 		return resp, err


### PR DESCRIPTION
Circuit breaker counter and defaults:
- counter.onFailure: increment consecutiveFailures instead of resetting consecutiveSuccesses twice, so the consecutive-failure trip branch in readyToOpen actually fires.
- counter.clear: also reset consecutiveFailures when entering a new generation.
- defaultRegionBreaker: set maxRequests (default 5); previously it was zero, causing the half-open -> closed transition on the first success.
- readyToOpen: replace hardcoded '> 5' with '>= s.maxFailNum' so the threshold follows configuration.
- docs: fix windowInterval comment (1min, not 5min) and counter comment (mutex-synchronized, not atomic).

Success classification in sendWithRegionBreaker:
- The old inline logic only set isSuccess=true inside the err.(*TencentCloudSDKError) branch, so when err was nil (genuine success) the type assertion failed and isSuccess stayed false. After 5 successful calls the breaker would open spuriously and silently route traffic to the backup endpoint. Introduce isBreakerSuccess() in circuit_breaker.go and use it from client.go.

Error wrapping preserves underlying causes:
- Add cause field + Unwrap() to TencentCloudSDKError so the original error is reachable via errors.Is / errors.As (Go 1.13+).
- Add NewTencentCloudSDKErrorWithCause constructor.
- Use it in netretry.go so the underlying net.Error is preserved instead of being flattened into the message string. Callers can now detect network errors with errors.As even after SDK wrapping.

Regression tests:
- circuit_breaker_test.go: counter typo, clear() rollover, consecutive-failure trip, isBreakerSuccess matrix, doesNotOpenOnSuccesses integration, halfOpenRequiresMaxRequests.
- errors/errors_test.go: Error/Unwrap/NewTencentCloudSDKErrorWithCause behaviour, errors.Is/As chain traversal.

Note: the polaris-specific ratelimitretry.go fix from the internal repo is not applicable here — this SDK does not integrate polaris.